### PR TITLE
Options should come from ParseOptions & DocumentOptions

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -1,14 +1,21 @@
-import type { DocumentOptions } from "yaml";
+import type { DocumentOptions, ParseOptions } from "yaml";
 
 /**
  * ESLint parserOptions to `yaml`'s Composer options.
  */
-export function parserOptionsToYAMLOption(options: any): DocumentOptions {
+export function parserOptionsToYAMLOption(options: any): DocumentOptions & ParseOptions {
   if (!options) {
     return {};
   }
-  const result: DocumentOptions = {};
+  const result: DocumentOptions & ParseOptions = {};
   const version = options.defaultYAMLVersion;
+
+  const fwd = ["uniqueKeys", "strict"] as const;
+
+  for(let opt of fwd)
+    if(opt in options)
+      result[opt] = options[opt];
+
   if (typeof version === "string" || typeof version === "number") {
     const sVer = String(version);
     if (sVer === "1.2" || sVer === "1.1") {


### PR DESCRIPTION
This PR allows more options to be forwarded to the parser.

Per YAML design.