### PR TITLE
refactor: drop lodash

### DIFF
--- a/.changeset/thin-needles-roll.md
+++ b/.changeset/thin-needles-roll.md
@@ -1,0 +1,5 @@
+---
+"yaml-eslint-parser": minor
+---
+
+Replace `lodash` to reduce the package installation size

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -13,7 +13,6 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
-    "lodash-es": "^4.17.21",
     "vue": "^3.5.12"
   },
   "devDependencies": {

--- a/explorer/vite.config.ts
+++ b/explorer/vite.config.ts
@@ -11,9 +11,6 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),
-      lodash: fileURLToPath(
-        new URL("./node_modules/lodash-es", import.meta.url),
-      ),
     },
   },
 });

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@types/benchmark": "^2.1.1",
     "@types/eslint": "^9.0.0",
     "@types/eslint-visitor-keys": "^3.0.0",
-    "@types/lodash": "^4.14.167",
     "@types/mocha": "^10.0.0",
     "@types/node": "^22.0.0",
     "@types/semver": "^7.3.10",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "homepage": "https://github.com/ota-meshi/yaml-eslint-parser#readme",
   "dependencies": {
     "eslint-visitor-keys": "^3.0.0",
-    "lodash": "^4.17.21",
     "yaml": "^2.0.0"
   },
   "devDependencies": {

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,6 +2,7 @@ import type { Comment, Locations, Position, Range, Token } from "./ast";
 import type { CST, DocumentOptions } from "yaml";
 import { ParseError } from ".";
 import { parserOptionsToYAMLOption } from "./options";
+import { sortedLastIndex } from "./utils";
 
 export class Context {
   public readonly code: string;
@@ -120,16 +121,7 @@ class LinesAndColumns {
   }
 
   public getLocFromIndex(index: number) {
-    // The implementation is mostly inspired by ESLint's context.sourceCode.getLocFromIndex
-    // See https://github.com/eslint/eslint/blob/f67d5e875324a9d899598b11807a9c7624021432/lib/languages/js/source-code/source-code.js#L657
-
-    // To figure out which line index is on, determine the last place at which index could
-    // be inserted into lineStartIndices to keep the list sorted.
-    const lastIndice = this.lineStartIndices.at(-1);
-    const lineNumber =
-      lastIndice != null && index >= lastIndice
-        ? this.lineStartIndices.length
-        : this.lineStartIndices.findIndex((el) => index < el);
+    const lineNumber = sortedLastIndex(this.lineStartIndices, index);
 
     return {
       line: lineNumber,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -205,3 +205,44 @@ function getTaggedValue(
 ${tagText} ${text}`).toJSON();
   return value;
 }
+
+/**
+ * Find the insertion position (index) of an item in an array with items sorted
+ * in ascending order; so that `splice(sortedIndex, 0, item)` would result in
+ * maintaining the array's sort-ness. The array can contain duplicates.
+ * If the item already exists in the array the index would be of the *last*
+ * occurrence of the item.
+ *
+ * Runs in O(logN) time.
+ *
+ * MIT License | Copyright (c) 2018 remeda | https://remedajs.com/
+ *
+ * The implementation is copied from remeda package:
+ * https://github.com/remeda/remeda/blob/878206eb3e8ec1c7f1300b1909b7aa629810c8bb/src/sortedLastIndex.ts
+ * https://github.com/remeda/remeda/blob/878206eb3e8ec1c7f1300b1909b7aa629810c8bb/src/internal/binarySearchCutoffIndex.ts#L1
+ *
+ * @param data - The (ascending) sorted array.
+ * @param item - The item to insert.
+ * @returns Insertion index (In the range 0..data.length).
+ * @signature
+ *    sortedLastIndex(data, item)
+ * @example
+ *    sortedLastIndex(['a','a','b','c','c'], 'c') // => 5
+ */
+export function sortedLastIndex<T>(array: readonly T[], item: T): number {
+  let lowIndex = 0;
+  let highIndex = array.length;
+
+  while (lowIndex < highIndex) {
+    const pivotIndex = (lowIndex + highIndex) >>> 1;
+    const pivot = array[pivotIndex];
+
+    if (pivot <= item) {
+      lowIndex = pivotIndex + 1;
+    } else {
+      highIndex = pivotIndex;
+    }
+  }
+
+  return highIndex;
+}


### PR DESCRIPTION
See also https://github.com/ota-meshi/eslint-plugin-yml/pull/406

`yaml-eslint-parser` is the last package in my `eslint-config-sukka` that depends on `lodash`.

It turns out that we actually don't even need `sortedLastIndex` at all. Instead, I replace it with a modified version of ESLint's implementation of `context.sourceCode.getLocFromIndex`, and all tests still pass on my machine:

<img width="1403" alt="image" src="https://github.com/user-attachments/assets/7530497a-17ad-4d8c-8351-6f5ec67c4bc0" />
